### PR TITLE
Fix Flight Launch compatibility

### DIFF
--- a/lib/tracon/aws.rb
+++ b/lib/tracon/aws.rb
@@ -144,9 +144,12 @@ module Tracon
           id: stack.stack_id,
           name: stack.stack_name,
           ctime: stack.creation_time,
+          parameters: {}.tap do |h|
+            stack.parameters.each {|p| h[p.parameter_key] = p.parameter_value}
+          end,
           tags: {}.tap do |h|
             stack.tags.each {|tag| h[tag.key] = tag.value}
-          end
+          end,
         }
       end
 

--- a/lib/tracon/cluster.rb
+++ b/lib/tracon/cluster.rb
@@ -14,6 +14,14 @@ module Tracon
       cluster_data[:parameters]['ClusterName'] || @qualified_name
     end
 
+    def scheduler_type
+      cluster_data[:parameters]['SchedulerType']
+    end
+
+    def flight_profile_bucket
+      cluster_data[:parameters]['FlightProfileBucket']
+    end
+
     def cu_in_use
       queues.reduce(0) do |memo, queue|
         memo += queue.current_cu

--- a/lib/tracon/cluster.rb
+++ b/lib/tracon/cluster.rb
@@ -1,11 +1,17 @@
 module Tracon
   class Cluster
     attr_accessor :domain
-    attr_accessor :name
+    attr_accessor :qualified_name
 
-    def initialize(domain, name)
+    def initialize(domain, qualified_name)
       @domain = domain
-      @name = name
+      # The cluster name, possibly qualified with a hash such as when launched
+      # by Flight Launch.
+      @qualified_name = qualified_name
+    end
+
+    def name
+      cluster_data[:parameters]['ClusterName'] || @qualified_name
     end
 
     def cu_in_use
@@ -20,11 +26,11 @@ module Tracon
 
     private
     def cluster_data
-      @cluster_data ||= AWS.cluster(@domain, @name)
+      @cluster_data ||= AWS.cluster(@domain, @qualified_name)
     end
 
     def queues
-      @queues ||= AWS.queues(@domain, @name).map do |queue_data|
+      @queues ||= AWS.queues(@domain, @qualified_name).map do |queue_data|
         Queue.new(queue_data[:spec], @cluster, queue_data)
       end
     end

--- a/lib/tracon/engine.rb
+++ b/lib/tracon/engine.rb
@@ -51,15 +51,15 @@ module Tracon
       end
 
       def started(cluster)
-        pool["#{cluster.name}.#{cluster.domain}"] = true
+        pool["#{cluster.qualified_name}.#{cluster.domain}"] = true
       end
 
       def completed(cluster)
-        pool["#{cluster.name}.#{cluster.domain}"] = false
+        pool["#{cluster.qualified_name}.#{cluster.domain}"] = false
       end
 
       def in_progress?(cluster)
-        pool["#{cluster.name}.#{cluster.domain}"] == true
+        pool["#{cluster.qualified_name}.#{cluster.domain}"] == true
       end
 
       private

--- a/lib/tracon/fly_config.rb
+++ b/lib/tracon/fly_config.rb
@@ -24,5 +24,9 @@ module Tracon
     def cluster_name
       @cluster.name
     end
+
+    def qualified_cluster_name
+      @cluster.qualified_name
+    end
   end
 end

--- a/lib/tracon/fly_queue_builder.rb
+++ b/lib/tracon/fly_queue_builder.rb
@@ -38,6 +38,7 @@ module Tracon
         'ComputeMaxNodes' => @max,
         'ComputeInstanceTypeOther' => @queue.type,
         'ComputeInstanceType' => 'other',
+        'ClusterName' => @queue.cluster.name,
         # XXX Min nodes!
       }
     end

--- a/lib/tracon/fly_queue_builder.rb
+++ b/lib/tracon/fly_queue_builder.rb
@@ -32,13 +32,16 @@ module Tracon
     end
 
     def overrides
+      cluster = @queue.cluster
       {
         'ComputeSpotPrice' => @queue.bid,
         'ComputeInitialNodes' => @desired,
         'ComputeMaxNodes' => @max,
         'ComputeInstanceTypeOther' => @queue.type,
         'ComputeInstanceType' => 'other',
-        'ClusterName' => @queue.cluster.name,
+        'ClusterName' => cluster.name,
+        'FlightProfileBucket' => cluster.flight_profile_bucket,
+        'SchedulerType' => cluster.scheduler_type,
         # XXX Min nodes!
       }
     end

--- a/lib/tracon/fly_runner.rb
+++ b/lib/tracon/fly_runner.rb
@@ -64,7 +64,7 @@ module Tracon
         ENV['FLY_EXE_PATH'],
         'cluster',
         @command,
-        @fly_config.cluster_name,
+        @fly_config.qualified_cluster_name,
         @fly_config.queue_name,
         '--domain', @fly_config.domain,
         '--access-key', @fly_config.access_key,

--- a/lib/tracon/fly_runner.rb
+++ b/lib/tracon/fly_runner.rb
@@ -49,7 +49,7 @@ module Tracon
       if @fly_config.template_set.present? && @command != 'delq'
         extra_args << '--template-set' << @fly_config.template_set
       end
-      if @fly_config.key_pair.present?
+      if @fly_config.key_pair.present? && @command != 'delq'
         extra_args << '--key-pair' << @fly_config.key_pair
       end
       if @fly_config.region.present?

--- a/lib/tracon/node.rb
+++ b/lib/tracon/node.rb
@@ -17,7 +17,7 @@ module Tracon
 
     private
     def node_data
-      @node_data ||= AWS.node(@queue.cluster.domain, @queue.cluster.name, @queue.name, @name)
+      @node_data ||= AWS.node(@queue.cluster.domain, @queue.cluster.qualified_name, @queue.name, @name)
     end
   end
 end

--- a/lib/tracon/queue.rb
+++ b/lib/tracon/queue.rb
@@ -76,7 +76,7 @@ module Tracon
     end
 
     def queue_data
-      @queue_data ||= AWS.queue(@cluster.domain, @cluster.name, @name)
+      @queue_data ||= AWS.queue(@cluster.domain, @cluster.qualified_name, @name)
     end
 
     def run_fly(runner)


### PR DESCRIPTION
This PR

1. Fixes tracon's compatibility with clusters launched by Flight Launch.
2. Fixes an issue with deleting queues.
3. Fixes an issue with queues not always having the same scheduler and customizer bucket as the master node.