### PR TITLE
Limited support for solo cluster

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,5 @@
 $: << 'lib'
+require 'tracon'
 require 'tracon/api'
 
 run Tracon::API

--- a/lib/tracon.rb
+++ b/lib/tracon.rb
@@ -1,0 +1,3 @@
+module Tracon
+  SOLO_CLUSTER_DOMAIN = 'cluster'
+end

--- a/lib/tracon/api.rb
+++ b/lib/tracon/api.rb
@@ -62,6 +62,16 @@ module Tracon
         end
 
         namespace :queues do
+          before do
+            if @domain == Tracon::SOLO_CLUSTER_DOMAIN
+              error!({
+                error: "422 Unprocessable Entity",
+                message: 'Not supported for solo clusters',
+              },
+              422)
+            end
+          end
+
           desc 'Show all queues for cluster.'
           get do
             Tracon::AWS.queues(@domain, params[:cluster])

--- a/lib/tracon/aws.rb
+++ b/lib/tracon/aws.rb
@@ -33,7 +33,9 @@ module Tracon
       end
 
       def cluster(domain, cluster_name)
-        res = describe_stacks(stack_name: "flight-#{domain}-#{cluster_name}-master")
+        stack_name = "flight-#{domain}-#{cluster_name}"
+        stack_name = "#{stack_name}-master" unless domain == Tracon::SOLO_CLUSTER_DOMAIN
+        res = describe_stacks(stack_name: stack_name)
         cluster_from_stack(res.stacks[0])
       rescue Aws::CloudFormation::Errors::ValidationError
         # doesn't exist
@@ -41,7 +43,9 @@ module Tracon
       end
 
       def cluster_token(domain, cluster_name)
-        res = describe_stacks(stack_name: "flight-#{domain}-#{cluster_name}-master")
+        stack_name = "flight-#{domain}-#{cluster_name}"
+        stack_name = "#{stack_name}-master" unless domain == Tracon::SOLO_CLUSTER_DOMAIN
+        res = describe_stacks(stack_name: stack_name)
         cr = configuration_result(res.stacks[0])
         return nil if cr.nil?
         cr['Token']


### PR DESCRIPTION
The support is limited to returning the cluster details.  Any attempt to query or modify the queues will result in a 422 error.

This allows the flight launch server to use tracon to get the outputs for a cluster it has previously launched.  The outputs contain the access url for the cluster which the launch client can use to have credit usages cards link to managing that cluster.

@mjtko you've previously said that tracon is for advanced clusters not solo clusters.  I think that this change makes sense, but if you're not happy with this limited support for solo clusters, please let me know.