### PR TITLE
Support specifying template set when creating compute queues

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/alces-software/flight-tracon",
   "scripts": {
     "dokku": {
-      "predeploy": "wget -q $FLY_DOWNLOAD_URL --output-document $FLY_EXE_PATH ; chmod +x $FLY_EXE_PATH"
+      "predeploy": "/app/bin/predeploy.sh"
     }
   }
 }

--- a/bin/predeploy.sh
+++ b/bin/predeploy.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euo pipefail
+
+main() {
+    parse_arguments "$@"
+    header "Downloading fly executables"
+    download_fly_executables
+}
+
+download_fly_executables() {
+    wget -q "${FLY_DOWNLOAD_URL}" --output-document "${FLY_EXE_PATH}"
+    chmod +x "${FLY_EXE_PATH}"
+    wget -q "${FLY_NEXT_DOWNLOAD_URL}" --output-document "${FLY_NEXT_EXE_PATH}"
+    chmod +x "${FLY_NEXT_EXE_PATH}"
+}
+
+header() {
+    echo -e "=====> $@"
+}
+
+subheader() {
+    echo -e "-----> $@"
+}
+
+indent() {
+    sed 's/^/       /'
+}
+
+usage() {
+    echo "Usage: $(basename $0) [options]"
+    echo
+    echo "Predeploy script to be ran during dokku deployment"
+    echo
+    echo -e "      --help\t\tShow this help message"
+}
+
+parse_arguments() {
+    while [[ $# > 0 ]] ; do
+        key="$1"
+
+        case $key in
+            --help)
+                usage
+                exit 0
+                ;;
+
+            *)
+                echo "$(basename $0): unrecognized option ${key}"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+main "$@"

--- a/lib/tracon/compute_unit_consumption_validator.rb
+++ b/lib/tracon/compute_unit_consumption_validator.rb
@@ -40,15 +40,21 @@ module Tracon
     end
 
     def launch_cluster
-      @launch_cluster ||= JSONAPI.load_launch_cluster(@cluster).resource
+      return @launch_cluster if defined? @launch_cluster
+      document = JSONAPI.load_launch_cluster(@cluster)
+      @launch_cluster = document.nil? ? nil : document.resource
     end
 
     def owner
-      @owner ||= launch_cluster.load_relationship(:owner).resource
+      return @owner if defined? @owner
+      document = launch_cluster.load_relationship(:owner)
+      @owner = document.nil? ? nil : document.resource
     end
 
     def payment
-      @payment ||= launch_cluster.load_relationship(:payment).resource
+      return @payment if defined? @payment
+      document = launch_cluster.load_relationship(:payment)
+      @payment = document.nil? ? nil : document.resource
     end
 
     def validate_owner_has_sufficient_compute_units

--- a/lib/tracon/engine.rb
+++ b/lib/tracon/engine.rb
@@ -86,14 +86,6 @@ module Tracon
         @errors = []
       end
 
-      def queue
-        {
-          min: @min,
-          max: @max,
-          desired: @desired
-        }
-      end
-
       def valid?
         if Engine.in_progress?(@cluster)
           @errors << 'operation in progress'
@@ -203,14 +195,6 @@ module Tracon
         @max = params[:max].to_i
         @max = @desired if @desired > @max
         @errors = []
-      end
-
-      def queue
-        {
-          min: @min,
-          max: @max,
-          desired: @desired
-        }
       end
 
       def valid?

--- a/lib/tracon/engine.rb
+++ b/lib/tracon/engine.rb
@@ -82,6 +82,7 @@ module Tracon
         @min = params[:min].to_i
         @max = params[:max].to_i
         @max = @desired if @desired > @max
+        @template_set = params[:template_set]
         @errors = []
       end
 
@@ -131,7 +132,7 @@ module Tracon
         if valid?
           # create queue params file
           # use fly to launch queue
-          @queue.create(@desired, @min, @max) do
+          @queue.create(@desired, @min, @max, @template_set) do
             # If the queue is created, record new credit usage.
             @credit_usage.create()
           end

--- a/lib/tracon/engine.rb
+++ b/lib/tracon/engine.rb
@@ -86,6 +86,14 @@ module Tracon
         @errors = []
       end
 
+      def queue
+        {
+          min: @min,
+          max: @max,
+          desired: @desired
+        }
+      end
+
       def valid?
         if Engine.in_progress?(@cluster)
           @errors << 'operation in progress'
@@ -195,6 +203,14 @@ module Tracon
         @max = params[:max].to_i
         @max = @desired if @desired > @max
         @errors = []
+      end
+
+      def queue
+        {
+          min: @min,
+          max: @max,
+          desired: @desired
+        }
       end
 
       def valid?

--- a/lib/tracon/engine.rb
+++ b/lib/tracon/engine.rb
@@ -82,7 +82,7 @@ module Tracon
         @min = params[:min].to_i
         @max = params[:max].to_i
         @max = @desired if @desired > @max
-        @template_set = params[:template_set]
+        @fly_params = params[:fly] || {}
         @errors = []
       end
 
@@ -124,7 +124,7 @@ module Tracon
         if valid?
           # create queue params file
           # use fly to launch queue
-          @queue.create(@desired, @min, @max, @template_set) do
+          @queue.create(@desired, @min, @max, @fly_params) do
             # If the queue is created, record new credit usage.
             @credit_usage.create()
           end

--- a/lib/tracon/fly_config.rb
+++ b/lib/tracon/fly_config.rb
@@ -1,33 +1,26 @@
 module Tracon
   class FlyConfig
-    attr_accessor :template_set
-    attr_accessor :key_pair
-    attr_accessor :region
+
     attr_accessor :access_key
-    attr_accessor :secret_key
+    attr_accessor :cluster_name
     attr_accessor :domain
-    
+    attr_accessor :key_pair
+    attr_accessor :qualified_cluster_name
+    attr_accessor :queue_name
+    attr_accessor :region
+    attr_accessor :secret_key
+    attr_accessor :template_set
+
     def initialize(cluster, queue)
-      @cluster = cluster
       @domain = cluster.domain
-      @queue = queue
       @access_key = ENV['AWS_ACCESS_KEY_ID']
       @secret_key = ENV['AWS_SECRET_ACCESS_KEY']
       @template_set = ENV['FLY_TEMPLATE_SET']
       @key_pair = ENV['FLY_KEY_PAIR']
       @region = Thread.current[:aws_region] || 'eu-west-1'
-    end
-
-    def queue_name
-      @queue.name
-    end
-
-    def cluster_name
-      @cluster.name
-    end
-
-    def qualified_cluster_name
-      @cluster.qualified_name
+      @queue_name = queue.name
+      @cluster_name = cluster.name
+      @qualified_cluster_name = cluster.qualified_name
     end
   end
 end

--- a/lib/tracon/fly_config.rb
+++ b/lib/tracon/fly_config.rb
@@ -13,18 +13,20 @@ module Tracon
     attr_accessor :secret_key
     attr_accessor :template_set
 
-    def initialize(cluster, queue, parameter_dir:nil, template_set:nil)
+    def initialize(cluster, queue, parameter_dir:nil, fly_params:{})
       @access_key = ENV['AWS_ACCESS_KEY_ID']
       @cluster_name = cluster.name
       @domain = cluster.domain
-      @fly_executable_path = ENV['FLY_EXE_PATH']
+      @fly_executable_path = fly_params[:version] == 'next' ?
+        ENV['FLY_NEXT_EXE_PATH'] :
+        ENV['FLY_EXE_PATH']
       @key_pair = ENV['FLY_KEY_PAIR']
       @parameter_dir = parameter_dir
       @qualified_cluster_name = cluster.qualified_name
       @queue_name = queue.name
       @region = Thread.current[:aws_region] || ENV['AWS_REGION'] || 'eu-west-1'
       @secret_key = ENV['AWS_SECRET_ACCESS_KEY']
-      @template_set = template_set || ENV['FLY_TEMPLATE_SET']
+      @template_set = fly_params[:template_set] || ENV['FLY_TEMPLATE_SET']
     end
   end
 end

--- a/lib/tracon/fly_config.rb
+++ b/lib/tracon/fly_config.rb
@@ -13,47 +13,18 @@ module Tracon
     attr_accessor :secret_key
     attr_accessor :template_set
 
-    def initialize
-      @fly_executable_path = ENV['FLY_EXE_PATH']
+    def initialize(cluster, queue, parameter_dir=nil)
       @access_key = ENV['AWS_ACCESS_KEY_ID']
-      @secret_key = ENV['AWS_SECRET_ACCESS_KEY']
+      @cluster_name = cluster.name
+      @domain = cluster.domain
+      @fly_executable_path = ENV['FLY_EXE_PATH']
+      @key_pair = ENV['FLY_KEY_PAIR']
+      @parameter_dir = parameter_dir
+      @qualified_cluster_name = cluster.qualified_name
+      @queue_name = queue.name
       @region = Thread.current[:aws_region] || ENV['AWS_REGION'] || 'eu-west-1'
-    end
-
-    class CreateQueueBuilder
-      def initialize(cluster, queue, parameter_dir)
-        @cluster = cluster
-        @queue = queue
-        @parameter_dir = parameter_dir
-      end
-
-      def build
-        FlyConfig.new.tap do |config|
-          config.cluster_name = @cluster.name
-          config.domain = @cluster.domain
-          config.key_pair = ENV['FLY_KEY_PAIR']
-          config.parameter_dir = @parameter_dir
-          config.qualified_cluster_name = @cluster.qualified_name
-          config.queue_name = @queue.name
-          config.template_set = ENV['FLY_TEMPLATE_SET']
-        end
-      end
-    end
-
-    class DestroyQueueBuilder
-      def initialize(cluster, queue)
-        @cluster = cluster
-        @queue = queue
-      end
-
-      def build
-        FlyConfig.new.tap do |config|
-          config.domain = @cluster.domain
-          config.queue_name = @queue.name
-          config.cluster_name = @cluster.name
-          config.qualified_cluster_name = @cluster.qualified_name
-        end
-      end
+      @secret_key = ENV['AWS_SECRET_ACCESS_KEY']
+      @template_set = ENV['FLY_TEMPLATE_SET']
     end
   end
 end

--- a/lib/tracon/fly_config.rb
+++ b/lib/tracon/fly_config.rb
@@ -4,7 +4,9 @@ module Tracon
     attr_accessor :access_key
     attr_accessor :cluster_name
     attr_accessor :domain
+    attr_accessor :fly_executable_path
     attr_accessor :key_pair
+    attr_accessor :parameter_dir
     attr_accessor :qualified_cluster_name
     attr_accessor :queue_name
     attr_accessor :region
@@ -12,25 +14,28 @@ module Tracon
     attr_accessor :template_set
 
     def initialize
+      @fly_executable_path = ENV['FLY_EXE_PATH']
       @access_key = ENV['AWS_ACCESS_KEY_ID']
       @secret_key = ENV['AWS_SECRET_ACCESS_KEY']
       @region = Thread.current[:aws_region] || ENV['AWS_REGION'] || 'eu-west-1'
     end
 
     class CreateQueueBuilder
-      def initialize(cluster, queue)
+      def initialize(cluster, queue, parameter_dir)
         @cluster = cluster
         @queue = queue
+        @parameter_dir = parameter_dir
       end
 
       def build
         FlyConfig.new.tap do |config|
-          config.key_pair = ENV['FLY_KEY_PAIR']
-          config.template_set = ENV['FLY_TEMPLATE_SET']
-          config.domain = @cluster.domain
-          config.queue_name = @queue.name
           config.cluster_name = @cluster.name
+          config.domain = @cluster.domain
+          config.key_pair = ENV['FLY_KEY_PAIR']
+          config.parameter_dir = @parameter_dir
           config.qualified_cluster_name = @cluster.qualified_name
+          config.queue_name = @queue.name
+          config.template_set = ENV['FLY_TEMPLATE_SET']
         end
       end
     end

--- a/lib/tracon/fly_config.rb
+++ b/lib/tracon/fly_config.rb
@@ -11,16 +11,44 @@ module Tracon
     attr_accessor :secret_key
     attr_accessor :template_set
 
-    def initialize(cluster, queue)
-      @domain = cluster.domain
+    def initialize
       @access_key = ENV['AWS_ACCESS_KEY_ID']
       @secret_key = ENV['AWS_SECRET_ACCESS_KEY']
-      @template_set = ENV['FLY_TEMPLATE_SET']
-      @key_pair = ENV['FLY_KEY_PAIR']
-      @region = Thread.current[:aws_region] || 'eu-west-1'
-      @queue_name = queue.name
-      @cluster_name = cluster.name
-      @qualified_cluster_name = cluster.qualified_name
+      @region = Thread.current[:aws_region] || ENV['AWS_REGION'] || 'eu-west-1'
+    end
+
+    class CreateQueueBuilder
+      def initialize(cluster, queue)
+        @cluster = cluster
+        @queue = queue
+      end
+
+      def build
+        FlyConfig.new.tap do |config|
+          config.key_pair = ENV['FLY_KEY_PAIR']
+          config.template_set = ENV['FLY_TEMPLATE_SET']
+          config.domain = @cluster.domain
+          config.queue_name = @queue.name
+          config.cluster_name = @cluster.name
+          config.qualified_cluster_name = @cluster.qualified_name
+        end
+      end
+    end
+
+    class DestroyQueueBuilder
+      def initialize(cluster, queue)
+        @cluster = cluster
+        @queue = queue
+      end
+
+      def build
+        FlyConfig.new.tap do |config|
+          config.domain = @cluster.domain
+          config.queue_name = @queue.name
+          config.cluster_name = @cluster.name
+          config.qualified_cluster_name = @cluster.qualified_name
+        end
+      end
     end
   end
 end

--- a/lib/tracon/fly_config.rb
+++ b/lib/tracon/fly_config.rb
@@ -13,7 +13,7 @@ module Tracon
     attr_accessor :secret_key
     attr_accessor :template_set
 
-    def initialize(cluster, queue, parameter_dir=nil)
+    def initialize(cluster, queue, parameter_dir:nil, template_set:nil)
       @access_key = ENV['AWS_ACCESS_KEY_ID']
       @cluster_name = cluster.name
       @domain = cluster.domain
@@ -24,7 +24,7 @@ module Tracon
       @queue_name = queue.name
       @region = Thread.current[:aws_region] || ENV['AWS_REGION'] || 'eu-west-1'
       @secret_key = ENV['AWS_SECRET_ACCESS_KEY']
-      @template_set = ENV['FLY_TEMPLATE_SET']
+      @template_set = template_set || ENV['FLY_TEMPLATE_SET']
     end
   end
 end

--- a/lib/tracon/fly_config_serializer.rb
+++ b/lib/tracon/fly_config_serializer.rb
@@ -1,0 +1,76 @@
+#
+# Serialize the given FlyConfig into command-line parameters and environment
+# for running fly.
+#
+class FlyConfigSerializer
+  class Result < Struct.new(:cmd, :env, :redacted_values)
+    def sanitized_cmd
+      cmd.map do |i|
+        redacted_values.include?(i) ? '[REDACTED]' : i
+      end
+    end
+  end
+
+  def initialize(fly_config)
+    @fly_config = fly_config
+  end
+
+  def serialize
+    redacted_values = [ @fly_config.access_key, @fly_config.secret_key ]
+    Result.new(command, environment, redacted_values)
+  end
+
+  def command
+    raise NotImplementedError
+  end
+
+  def add_arg_if_present(arg_name, value)
+    [].tap do |args|
+      if value.present?
+        args << arg_name << value
+      end
+    end
+  end
+
+  def environment
+    {
+      "FLY_SIMPLE_OUTPUT" => "true"
+    }
+  end
+
+
+  class CreateQueueSerializer < FlyConfigSerializer
+    def command
+      [
+        @fly_config.fly_executable_path,
+        'cluster',
+        'addq',
+        @fly_config.qualified_cluster_name,
+        @fly_config.queue_name,
+        '--domain', @fly_config.domain,
+        '--access-key', @fly_config.access_key,
+        '--secret-key', @fly_config.secret_key,
+        *add_arg_if_present('--template-set', @fly_config.template_set),
+        *add_arg_if_present('--key-pair', @fly_config.key_pair),
+        *add_arg_if_present('--region', @fly_config.region),
+        '--parameter-directory', @fly_config.parameter_dir,
+      ]
+    end
+  end
+
+  class DestroyQueueSerializer < FlyConfigSerializer
+    def command
+      [
+        @fly_config.fly_executable_path,
+        'cluster',
+        'delq',
+        @fly_config.qualified_cluster_name,
+        @fly_config.queue_name,
+        '--domain', @fly_config.domain,
+        '--access-key', @fly_config.access_key,
+        '--secret-key', @fly_config.secret_key,
+        *add_arg_if_present('--region', @fly_config.region),
+      ]
+    end
+  end
+end

--- a/lib/tracon/fly_queue_builder.rb
+++ b/lib/tracon/fly_queue_builder.rb
@@ -26,7 +26,7 @@ module Tracon
     def merge_overrides
       puts "Merging overrides for 'cluster-compute' parameters"
       params = YAML.load_file(File.join(parameter_dir, "cluster-compute.yml"))
-      new_params = params.merge(overrides)
+      new_params = params.merge(overrides.slice(*params.keys))
       File.write(File.join(@parameter_dir, "cluster-compute.yml.bak"), params.to_yaml)
       File.write(File.join(@parameter_dir, "cluster-compute.yml"), new_params.to_yaml)
     end

--- a/lib/tracon/fly_queue_builder.rb
+++ b/lib/tracon/fly_queue_builder.rb
@@ -3,11 +3,12 @@ require 'yaml'
 
 module Tracon
   class FlyQueueBuilder
-    def initialize(queue, desired, min, max)
+    def initialize(queue, desired, min, max, fly_config)
       @queue = queue
       @desired = desired
       @min = min
       @max = max
+      @fly_config = fly_config
     end
 
     def perform
@@ -47,7 +48,8 @@ module Tracon
     end
 
     def create_parameter_directory
-      cmd = [ENV['FLY_EXE_PATH'], '--create-parameter-directory', parameter_dir]
+      fly_exe_path = @fly_config.fly_executable_path
+      cmd = [fly_exe_path, '--create-parameter-directory', parameter_dir]
       puts "Creating fly parameter directory: #{cmd.inspect}"
       exit_status = Open3.popen3(*cmd) do |stdin, stdout, stderr, wait_thr|
         stdin.close

--- a/lib/tracon/fly_runner.rb
+++ b/lib/tracon/fly_runner.rb
@@ -9,14 +9,14 @@
 require 'open3'
 
 #
-# Run the `fly` command described by the given `fly_params`.
+# Run the `fly` command described by the given `fly_command`.
 #
 module Tracon
   class FlyRunner
     attr_reader :stdout, :stderr
 
-    def initialize(fly_params)
-      @fly_params = fly_params
+    def initialize(fly_command)
+      @fly_command = fly_command
     end
 
     def perform
@@ -29,8 +29,8 @@ module Tracon
     end
 
     def launch_with_popen3
-      cmd = @fly_params.cmd
-      env = @fly_params.env
+      cmd = @fly_command.cmd
+      env = @fly_command.env
       @exit_status = Open3.popen3(env, *cmd) do |stdin, stdout, stderr, wait_thr|
         stdin.close
         @stdout = stdout.read
@@ -40,7 +40,7 @@ module Tracon
     end
 
     def log_params
-      puts "Running command #{@fly_params.sanitized_cmd.inspect} in env #{@fly_params.env.inspect}"
+      puts "Running command #{@fly_command.sanitized_cmd.inspect} in env #{@fly_command.env.inspect}"
     end
   end
 end

--- a/lib/tracon/fly_runner.rb
+++ b/lib/tracon/fly_runner.rb
@@ -46,16 +46,14 @@ module Tracon
 
     def build_command_and_environment
       extra_args = []
-      if @fly_config.template_set.present? && @command != 'delq'
+      if @fly_config.template_set.present?
         extra_args << '--template-set' << @fly_config.template_set
       end
-      if @fly_config.key_pair.present? && @command != 'delq'
+      if @fly_config.key_pair.present?
         extra_args << '--key-pair' << @fly_config.key_pair
       end
       if @fly_config.region.present?
         extra_args << '--region' << @fly_config.region
-      else
-        extra_args << '--region' << (ENV['AWS_REGION'] || 'eu-west-1')
       end
       if @parameter_dir
         extra_args << '--parameter-directory' << @parameter_dir

--- a/lib/tracon/fly_runner.rb
+++ b/lib/tracon/fly_runner.rb
@@ -9,20 +9,11 @@
 require 'open3'
 
 #
-# Run the `fly` command and get the stack arn from the output.
-#
-# We don't want to be blocked waiting for the stack to finish launching in
-# order to obatin the arn.  This class runs the fly command and reads its
-# output as it is produced, so that it can obtain the arn as soon as possible.
-#
-# A number of utility methods for checking the status of this command have
-# been added.
+# Run the `fly` command described by the given `fly_params`.
 #
 module Tracon
   class FlyRunner
-    attr_reader :arn,
-                :stdout,
-                :stderr
+    attr_reader :stdout, :stderr
 
     def initialize(fly_params)
       @fly_params = fly_params
@@ -37,41 +28,18 @@ module Tracon
       @exit_status && ! @exit_status.success?
     end
 
-    def waiting_for_arn?
-      arn.nil? && @exit_status.nil?
-    end
-
     def launch_with_popen3
       cmd = @fly_params.cmd
       env = @fly_params.env
       @exit_status = Open3.popen3(env, *cmd) do |stdin, stdout, stderr, wait_thr|
         stdin.close
-        stdout_bytes_read = read_arn(stdout, wait_thr)
-        @stdout = stdout_bytes_read
-        @stdout << stdout.read
+        @stdout = stdout.read
         @stderr = stderr.read
         wait_thr.value
       end
     end
 
-    def read_arn(stdout, wait_thr)
-      stdout_read = ""
-      while wait_thr.alive?
-        lines = stdout.readpartial(512)
-        stdout_read << lines
-        stdout_read.split("\n").each do |line|
-          if line =~ /^CREATE_IN_PROGRESS\s*[-0-9a-zA-Z]*#{@fly_config.queue_name}/
-            @arn = line.gsub(/^[^(]*\(([^)]*)\)/, '\1')
-            return stdout_read
-          end
-        end
-      end
-      stdout_read
-    rescue EOFError
-      stdout_read
-    end
-
-    def log_cmd
+    def log_params
       puts "Running command #{@fly_params.sanitized_cmd.inspect} in env #{@fly_params.env.inspect}"
     end
   end

--- a/lib/tracon/queue.rb
+++ b/lib/tracon/queue.rb
@@ -141,9 +141,14 @@ module Tracon
       block.call unless block.nil?
     end
 
-    def create(desired, min, max, &block)
+    def create(desired, min, max, template_set=nil, &block)
       parameter_dir = FlyQueueBuilder.new(self, desired, min, max).perform
-      fly_config = FlyConfig.new(@cluster, self, parameter_dir)
+      fly_config = FlyConfig.new(
+        @cluster,
+        self,
+        parameter_dir: parameter_dir,
+        template_set: template_set
+      )
       fly_params = FlyConfigSerializer::CreateQueueSerializer.new(fly_config).serialize
       runner = FlyRunner.new(fly_params)
       run_fly(runner, &block)

--- a/lib/tracon/queue.rb
+++ b/lib/tracon/queue.rb
@@ -144,11 +144,13 @@ module Tracon
 
     def create(desired, min, max, &block)
       parameter_dir = FlyQueueBuilder.new(self, desired, min, max).perform
+      fly_config = FlyConfig::CreateQueueBuilder.new(@cluster, self).build
       runner = FlyRunner.new('addq', parameter_dir, fly_config)
       run_fly(runner, &block)
     end
 
     def destroy(skip_engine_update: false, &block)
+      fly_config = FlyConfig::DestroyQueueBuilder.new(@cluster, self).build
       run_fly(
         FlyRunner.new('delq', nil, fly_config),
         skip_engine_update: skip_engine_update,
@@ -157,10 +159,6 @@ module Tracon
     end
 
     private
-    def fly_config
-      FlyConfig.new(@cluster, self)
-    end
-
     def queue_data
       @queue_data ||= AWS.queue(@cluster.domain, @cluster.qualified_name, @name)
     end

--- a/lib/tracon/queue.rb
+++ b/lib/tracon/queue.rb
@@ -149,16 +149,16 @@ module Tracon
         parameter_dir: parameter_dir,
         template_set: template_set
       )
-      fly_params = FlyConfigSerializer::CreateQueueSerializer.new(fly_config).serialize
-      runner = FlyRunner.new(fly_params)
+      fly_command = FlyConfigSerializer::CreateQueueSerializer.new(fly_config).serialize
+      runner = FlyRunner.new(fly_command)
       run_fly(runner, &block)
     end
 
     def destroy(skip_engine_update: false, &block)
       fly_config = FlyConfig.new(@cluster, self)
-      fly_params = FlyConfigSerializer::DestroyQueueSerializer.new(fly_config).serialize
+      fly_command = FlyConfigSerializer::DestroyQueueSerializer.new(fly_config).serialize
       run_fly(
-        FlyRunner.new(fly_params),
+        FlyRunner.new(fly_command),
         skip_engine_update: skip_engine_update,
         &block
       )

--- a/lib/tracon/queue.rb
+++ b/lib/tracon/queue.rb
@@ -141,14 +141,14 @@ module Tracon
       block.call unless block.nil?
     end
 
-    def create(desired, min, max, template_set=nil, &block)
-      parameter_dir = FlyQueueBuilder.new(self, desired, min, max).perform
+    def create(desired, min, max, fly_params={}, &block)
       fly_config = FlyConfig.new(
         @cluster,
         self,
-        parameter_dir: parameter_dir,
-        template_set: template_set
+        fly_params: fly_params,
       )
+      parameter_dir = FlyQueueBuilder.new(self, desired, min, max, fly_config).perform
+      fly_config.parameter_dir = parameter_dir
       fly_command = FlyConfigSerializer::CreateQueueSerializer.new(fly_config).serialize
       runner = FlyRunner.new(fly_command)
       run_fly(runner, &block)

--- a/lib/tracon/queue.rb
+++ b/lib/tracon/queue.rb
@@ -175,7 +175,6 @@ module Tracon
           runner.perform
           puts runner.stdout
           puts runner.stderr
-          puts runner.arn
           block.call unless block.nil?
         rescue
           STDERR.puts $!.message

--- a/lib/tracon/queue.rb
+++ b/lib/tracon/queue.rb
@@ -143,14 +143,14 @@ module Tracon
 
     def create(desired, min, max, &block)
       parameter_dir = FlyQueueBuilder.new(self, desired, min, max).perform
-      fly_config = FlyConfig::CreateQueueBuilder.new(@cluster, self, parameter_dir).build
+      fly_config = FlyConfig.new(@cluster, self, parameter_dir)
       fly_params = FlyConfigSerializer::CreateQueueSerializer.new(fly_config).serialize
       runner = FlyRunner.new(fly_params)
       run_fly(runner, &block)
     end
 
     def destroy(skip_engine_update: false, &block)
-      fly_config = FlyConfig::DestroyQueueBuilder.new(@cluster, self).build
+      fly_config = FlyConfig.new(@cluster, self)
       fly_params = FlyConfigSerializer::DestroyQueueSerializer.new(fly_config).serialize
       run_fly(
         FlyRunner.new(fly_params),


### PR DESCRIPTION
The API for creating a queue now supports specifying the template set to use.  The template set is given in the body of the request as described below.

Different template sets support different parameters. For instance, `markt-20171010` supports the `AutoscalingPolicy` parameter whilst the `2018.1-dev` template set does not.  In order to use the correct set of parameters for the template set it was also necessary to add support for specifying the version of fly to use in the same way that we do for flight launch.  That is, we either use the "current" or "next" version of fly.

The `fly`, `fly.template_set` and `fly.version` parameter are all optional.

The new body of the queue creation API is now:

```json
{
  "desired": 0,
  "max": 0,
  "min": 0,
  "fly": {
    "template_set": "2018.1-dev",
    "version": "next"
  }
}
```

I've tested this by making the following change to `alces compute addq`:

```diff
[root@login1(anxiously-joke-nail-clippers) ~]# diff -u /opt/clusterware/libexec/compute/share/functions.sh.orig /opt/clusterware/libexec/compute/share/functions.sh
--- /opt/clusterware/libexec/compute/share/functions.sh.orig	2018-05-23 10:13:11.321688536 +0000
+++ /opt/clusterware/libexec/compute/share/functions.sh	2018-05-23 10:13:16.803674169 +0000
@@ -104,7 +104,7 @@
   size="$1"
   min="$2"
   max="$3"
-  ${_COMPUTE_JO} desired=$size min=$min max=$max
+  ${_COMPUTE_JO} desired=$size min=$min max=$max fly=$(${_COMPUTE_JO} template_set=2018.1-dev version="next")
 }
 
 _compute_value_for_queue() {

```

I've not done anything to add proper support to the client for specifying the template set or version.  @mjtko If you want me to look into that let me know.
